### PR TITLE
Make a bare command run output the classic flag by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ You can also add pridefetch to your `$PATH` to run it anywhere<br>
 ```bash
 mv pridefetch /usr/bin/
 ```
+
+## Running on NixOS
+#### If your system supports flakes
+You can run pridefetch quickly
+
+```bash
+nix run github:SpyHoodle/pridefetch -- -f trans
+```
+
+Or install it
+
+```
+nix profile install github:SpyHoodle/pridefetch
+pridefetch -f trans
+```

--- a/pridefetch
+++ b/pridefetch
@@ -100,14 +100,17 @@ def main():
         # Draw the chosen flag and system information
         draw_fetch(args.flag, args.width)
 
-    if args.random:
+    elif args.random:
         # Choose a flag at random from a list of comma-seperated flags
         flag_choices = args.random.split(",")
         draw_fetch(random_choice(flag_choices), args.width)
 
-    if args.list:
+    elif args.list:
         # List out all the available flags
         print(f"Available flags:\n{', '.join(flags)}")
+
+    else:
+        draw_fetch("classic", args.width)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently the command outputs nothing if you just run `pridefetch`; this PR makes the flag default to classic instead