### PR TITLE
Change to nix system package number

### DIFF
--- a/packages.py
+++ b/packages.py
@@ -6,7 +6,8 @@ commands = [
     "yum list installed",
     "dnf list installed",
     "qlist -I",
-    "nix-store -qR /run/current-system/sw",
+    "rpm -qa",
+    "nix-store -qR /run/current-system/sw"
 ]
 
 def get_num_packages() -> (int, bool):

--- a/packages.py
+++ b/packages.py
@@ -6,9 +6,7 @@ commands = [
     "yum list installed",
     "dnf list installed",
     "qlist -I",
-    "nix profile list",
-    "nix-env -q",
-    "rpm -qa",
+    "nix-store -qR /run/current-system/sw",
 ]
 
 def get_num_packages() -> (int, bool):


### PR DESCRIPTION
This fixes the issue of nix packages not showing on users that either use nix-env, as nix profile is ran first. This command instead shows all the nix-system packages, the same command neofetch uses for nix-system packages.