### PR TITLE
Update the flake such that it uses nixpkgs' package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,9 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653087707,
-        "narHash": "sha256-zfno3snrzZTWQ2B7K53QHrGZwrjnJLTRPalymrSsziU=",
-        "path": "/nix/store/3g25cg20m43hvsy17d7nz0jxwk79a77w-source",
-        "rev": "cbd40c72b2603ab54e7208f99f9b35fc158bc009",
+        "lastModified": 0,
+        "narHash": "sha256-kP4m7ZgFYj8fh7oW2L0uW0sJw/e0k1HY26HYJcvNEKM=",
+        "path": "/nix/store/ayvjhxw0zjwp5ipvwlhbhrwqqw553h2f-source",
         "type": "path"
       },
       "original": {
@@ -13,9 +12,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1654245945,
+        "narHash": "sha256-PV6MZ+HuNnyLxQGa2rwt0BmCRkQS2xqhc+SeJLQM+WU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "442db9429b9fbdb6352cfb937afc8ecccfe2633f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,23 @@
   description = "A flake to run pridefetch";
 
   inputs = {
-    nixpkgs-master.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-master }: let
+  outputs = { self, nixpkgs, nixpkgs-unstable }: let
     system = "x86_64-linux";
  
-    forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.supported.hydra (system: f system);
+    forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: f system);
   in rec {
     packages = forAllSystems (system: let 
       pkgs = import nixpkgs {
         inherit system;
       };
-      pkgs-master = import nixpkgs-master {
+      pkgs-unstable = import nixpkgs-unstable {
         inherit system;
       };
     in {
-      pridefetch = pkgs-master.pridefetch.overrideAttrs (finalAttrs: previousAttrs: {
+      pridefetch = pkgs-unstable.pridefetch.overrideAttrs (finalAttrs: previousAttrs: {
         src = builtins.path { path = ./.; name = "pridefetch"; };
       });
     });

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,11 @@
 {
   description = "A flake to run pridefetch";
 
-  outputs = { self, nixpkgs }: let
+  inputs = {
+    nixpkgs-master.url = "github:nixos/nixpkgs/master";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-master }: let
     system = "x86_64-linux";
  
     forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.supported.hydra (system: f system);
@@ -10,46 +14,13 @@
       pkgs = import nixpkgs {
         inherit system;
       };
-    in {
-      pridefetch = pkgs.stdenv.mkDerivation {
-        name = "pridefetch";
-        buildInputs = with pkgs; [
-          (python39.withPackages (pythonPackages: with pythonPackages; [
-            distro          
-          ]))
-          zip
-        ];
-        unpackPhase = "true";
-        installPhase = ''
-          mkdir -p $out/bin
-          cd ${./src}
-          zip -r $out/pridefetch.zip *
-          echo '#!/usr/bin/env python' | cat - $out/pridefetch.zip > $out/bin/pridefetch
-          chmod +x $out/bin/pridefetch
-          rm $out/pridefetch.zip
-        '';
-        meta = with pkgs.lib; {
-          description = "Print out system statistics with pride flags";
-          longDescription = ''
-            Pridefetch prints your system statistics (similarly to neofetch, screenfetch or pfetch) along with a pride flag.
-            The flag which is printed is configurable, as well as the width of the output.
-          '';
-          homepage = https://github.com/SpyHoodle/pridefetch;
-          license = "bsd"; 
-          # https://static.domenkozar.com/nixpkgs-manual-sphinx-exp/meta.xml.html
-          # > Catch-all for licenses that are essentially similar to the original BSD license with the advertising clause removed, i.e. permissive non-copyleft free software licenses. This includes the X11 (“MIT”) License.
-          # our license is MIT, so BSD is set here
-          maintainers = [
-            {
-              email = "skyler3665@gmail.com";
-              github = "minion3665";
-              githubId = 34243578;
-              name = "Skyler Grey";
-            }
-          ];  # TODO: Replace this with a reference to the maintainer list after adding myself to it
-          platforms = systems.supported.hydra;
-        };
+      pkgs-master = import nixpkgs-master {
+        inherit system;
       };
+    in {
+      pridefetch = pkgs-master.pridefetch.overrideAttrs (finalAttrs: previousAttrs: {
+        src = builtins.path { path = ./.; name = "pridefetch"; };
+      });
     });
 
     defaultPackage = forAllSystems (system: self.packages.${system}.pridefetch);

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A flake to run pridefetch";
 
   inputs = {
-    nixpkgs-master.url = "github:nixos/nixpkgs/master";
+    nixpkgs-master.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
   outputs = { self, nixpkgs, nixpkgs-master }: let

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,10 @@
 
   outputs = { self, nixpkgs, nixpkgs-unstable }: let
     system = "x86_64-linux";
- 
+
     forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: f system);
   in rec {
-    packages = forAllSystems (system: let 
+    packages = forAllSystems (system: let
       pkgs = import nixpkgs {
         inherit system;
       };


### PR DESCRIPTION
This pull updates the flake so that it no longer relies an on a copy of the .nix expression. Instead, it overrides the src of the derivation on nixpkgs and uses it instead.

~~⚠️ Please wait until the package is in nixpkgs-unstable before merging. On this early version we're requiring people to download the master branch of nixpkgs to build a flake~~ This is completed and the pull request is ready to merge

This pull request closes #9 