### PR TITLE
Choose what stats are displayed (inital implementation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.idea

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -129,6 +129,28 @@ def create_fetch(flag_name: str, show_stats=None, width=None):
     draw_fetch(flag, width, data)
 
 
+def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list) -> bool:
+    # Remove empty string items and remove whitespaces
+    arguments = [argument.strip() for argument in arguments if argument.strip()]
+
+    # If there are any arguments remaining
+    if len(arguments) > 0:
+        for argument in arguments:
+            # If the argument isn't in valid_arguments, it isn't valid
+            if argument not in valid_arguments:
+                print(f"{bold}{red}Error: Invalid argument '{argument}' for '{arg_flag}'{reset}\n"
+                      f"  {red}╰> must be one of '{', '.join(valid_arguments)}'{reset}")
+                return False
+
+    # Otherwise, the user must have typed comma(s) without any arguments
+    else:
+        print(f"{bold}{red}Error: No arguments given for '{arg_flag}'{reset}\n"
+              f"  {red}╰> must be one of '{', '.join(valid_arguments)}'{reset}")
+        return False
+
+    return True
+
+
 def main():
     # Argument configuration - options
     parser = ArgumentParser()
@@ -150,25 +172,8 @@ def main():
         # Collect chosen stats if they exist
         show_stats = args.stats.split(",")
 
-        # Remove empty string items and remove whitespaces
-        show_stats = [stat.strip() for stat in show_stats if stat.strip()]
-
-        # If the user has entered stats
-        if len(show_stats) > 0:
-            for stat in show_stats:
-                # If the stat isn't in stats, it isn't valid
-                if stat not in stats:
-                    # Tell the user the stat is invalid
-                    print(f"{bold}{red}Error: Invalid stat '{stat}' (does not exist){reset}")
-
-                    # Exit with an error code
-                    exit(1)
-
-        else:
-            # The user must have typed a comma without any stats
-            print(f"{bold}{red}Error: No stats given with '--stats'{reset}")
-
-            # Exit with an error code
+        # Check if the passed arguments are valid, if not, exit with an error
+        if not check_valid_arguments("--stats", show_stats, list(stats)):
             exit(1)
 
     else:
@@ -180,8 +185,14 @@ def main():
         create_fetch(args.flag, show_stats, args.width)
 
     elif args.random:
-        # Choose a flag at random from a list of comma-seperated flags
+        # Collect chosen flags if they exist
         flag_choices = args.random.split(",")
+
+        # Check if the passed arguments are valid, if not, exit with an error
+        if not check_valid_arguments("--random", flag_choices, list(flags)):
+            exit(1)
+
+        # Draw a randomly selected flag from the list
         create_fetch(random_choice(flag_choices), show_stats, args.width)
 
     elif args.list:

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -63,8 +63,7 @@ def color256(col: int, bg_fg: str) -> str:
     return f"\033[{48 if bg_fg == 'bg' else 38};5;{col}m"
 
 
-def generate_fetch(flag_name: str, stat_choices: list = None, width: int = None) -> \
-        tuple[list[int | Any] | list[int] | Any, int | None, list[str]]:
+def generate_fetch(flag_name: str, stat_choices: list = None, width: int = None) -> (list, int, list):
     # Load the chosen flag from the dictionary of flags
     flag = flags[flag_name]
 
@@ -133,9 +132,6 @@ def create_fetch(flag_name: str, stat_choices: list = None, width: int = None):
 
 
 def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list) -> bool:
-    # Remove empty string items and remove whitespaces
-    arguments = [argument.strip() for argument in arguments if argument.strip()]
-
     # If there are any arguments remaining
     if len(arguments) > 0:
         for argument in arguments:
@@ -175,6 +171,10 @@ def main():
         # Collect chosen stats if they exist
         show_stats = args.stats.split(",")
 
+        # Remove whitespace stat choices
+        # TODO: Rename and create function
+        show_stats = [flag.strip() for flag in show_stats if flag.strip()]
+
         # Check if the passed arguments are valid, if not, exit with an error
         if not check_valid_arguments("--stats", show_stats, list(stats)):
             exit(1)
@@ -190,6 +190,9 @@ def main():
     elif args.random:
         # Collect chosen flags if they exist
         flag_choices = args.random.split(",")
+
+        # Remove empty items and remove whitespaces
+        flag_choices = [flag.strip() for flag in flag_choices if flag.strip()]
 
         # Check if the passed arguments are valid, if not, exit with an error
         if not check_valid_arguments("--random", flag_choices, list(flags)):

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -134,7 +134,7 @@ def main():
 
     elif args.stats:
         # Collect chosen stats if they exist
-        show_stats = args.stats.split(",").strip()
+        show_stats = args.stats.split(",")
 
     else:
         # Otherwise, use the default stats

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -76,8 +76,16 @@ def generate_fetch(flag_name: str, show_stats=None, width=None):
 
     # Add the chosen stats to the list row_data
     for stat in show_stats:
+        # Calculate the value for the stat by running its function
         value = stats[stat]()
-        row = f"{row_color}{stat}: {reset}{value}"
+
+        # Calculate the correct amount of spaces to keep the stat values in line with each other
+        spaces = ((len(max(show_stats)) - len(stat)) + 1) * " "
+
+        # Generate a row
+        row = f"{row_color}{stat}:{spaces}{reset}{value}"
+
+        # Add the row to the data
         data.append(row)
 
     # Until the flag is a greater length than the data

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -108,6 +108,9 @@ def draw_fetch(flag: list, width: int, data: list):
 
 
 def create_fetch(flag_name: str, show_stats=None, width=None):
+    # Check if the flag exists in the dictionary of flags
+    assert flag_name in flags.keys(), f"flag '{flag_name}' is not a valid flag"
+
     flag, width, data = generate_fetch(flag_name, show_stats, width)
     draw_fetch(flag, width, data)
 
@@ -115,12 +118,12 @@ def create_fetch(flag_name: str, show_stats=None, width=None):
 def main():
     # Argument configuration - options
     parser = ArgumentParser()
-    parser.add_argument("-f", "--flag", help="displays the chosen flag")
+    parser.add_argument("-l", "--list", help="lists all the flags and stats that can be displayed", action="store_true")
+    parser.add_argument("-a", "--all-stats", help="use all the available stats (overrides '--stats')", action="store_true")
+    parser.add_argument("-f", "--flag", help="displays a flag of your choice")
     parser.add_argument("-r", "--random", help="randomly choose a flag from a comma-seperated list")
     parser.add_argument("-s", "--stats", help="choose the stats to appear from a comma-seperated list")
     parser.add_argument("-w", "--width", help="choose a custom width for the flag", type=int)
-    parser.add_argument("-a", "--all-stats", help="use all the available stats (overrides '--stats')", action="store_true")
-    parser.add_argument("-l", "--list", help="lists all the flags and stats that can be displayed", action="store_true")
 
     # Parse (collect) any arguments
     args = parser.parse_args()
@@ -131,16 +134,13 @@ def main():
 
     elif args.stats:
         # Collect chosen stats if they exist
-        show_stats = args.stats.split(",")
+        show_stats = args.stats.split(",").strip()
 
     else:
         # Otherwise, use the default stats
         show_stats = None
 
     if args.flag:
-        # Check if the flag exists in the dictionary of flags
-        assert args.flag in flags.keys(), f"flag '{args.flag}' is not a valid flag"
-
         # Draw the chosen flag and system information
         create_fetch(args.flag, show_stats, args.width)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -169,7 +169,7 @@ def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list)
 def parse_comma_arguments(arg_flag: str, comma_arguments: str, valid_arguments: list) -> list:
     """
     Parses comma seperated arguments and checks if they are valid
-    :param arg_flag: The argument flag e.g. --random, --stats etc.
+    :param arg_flag: The argument command line flag e.g. --random, --stats etc.
     :param comma_arguments: Raw string of user inputted arguments including commas
     :param valid_arguments: The valid list of arguments to check against
     :return: Parsed arguments if valid, exits the program if invalid
@@ -195,7 +195,7 @@ def main():
     Main function that evaluates command line arguments
     """
 
-    # Argument configuration - options
+    # Argument configuration - pridefetch command line options
     parser = ArgumentParser()
     parser.add_argument("-l", "--list", help="lists all flags and stats that can be displayed", action="store_true")
     parser.add_argument("-a", "--all-stats", help="use all available stats (overrides '--stats')", action="store_true")

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -139,9 +139,28 @@ def create_fetch(flag_name: str, show_stats: list = None, width: int = None) -> 
     draw_fetch(flag, width, data)
 
 
+def check_valid_argument(arg_flag: str, argument: str, valid_arguments: list) -> bool:
+    """
+    Checks if an argument is valid by checking if it's in a list of valid arguments
+    :param arg_flag: The argument flag e.g. --random, --stats etc.
+    :param argument: A user inputted argument
+    :param valid_arguments: The valid list of arguments to check against
+    :return: True if the argument is valid, False if not
+    """
+
+    # Check if argument is valid, by checking if it is not in valid_arguments
+    if argument not in valid_arguments:
+        _print_error(f"Invalid argument '{argument}' given for '{arg_flag}'",
+                     f"must be one of '{', '.join(valid_arguments)}'")
+        return False
+
+    else:
+        return True
+
+
 def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list) -> bool:
     """
-    Checks if arguments are valid
+    Checks if arguments are valid by checking if they are in a list of valid arguments
     :param arg_flag: The argument flag e.g. --random, --stats etc.
     :param arguments: A list of user inputted arguments
     :param valid_arguments: The valid list of arguments to check against
@@ -152,15 +171,13 @@ def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list)
     if len(arguments) > 0:
         for argument in arguments:
             # If the argument isn't in valid_arguments, it isn't valid
-            if argument not in valid_arguments:
-                print(f"{color.bold}{color.red}Error: Invalid argument '{argument}' for '{arg_flag}'{color.clear}\n"
-                      f"  {color.red}╰> must be one of '{', '.join(valid_arguments)}'{color.clear}")
+            if not check_valid_argument(arg_flag, argument, valid_arguments):
                 return False
 
     # Otherwise, the user must have typed comma(s) without any arguments
     else:
-        print(f"{color.bold}{color.red}Error: No arguments given for '{arg_flag}'{color.clear}\n"
-              f"  {color.red}╰> must be one of '{', '.join(valid_arguments)}'{color.clear}")
+        _print_error(f"No arguments given for '{arg_flag}'",
+                     f"must be one of '{', '.join(valid_arguments)}'")
         return False
 
     return True
@@ -188,6 +205,22 @@ def parse_comma_arguments(arg_flag: str, comma_arguments: str, valid_arguments: 
     # Otherwise return the arguments
     else:
         return arguments
+
+
+def _print_error(error: str, help_message: str = None) -> None:
+    """
+    Prints an error message with optionally an extra help message
+    :param error: Error message to print
+    :param help_message: Optional help message
+    :return:
+    """
+
+    # Print out the error message
+    print(f"{color.bold}{color.red}Error: {error}{color.clear}")
+
+    # If the help message was given, print it out
+    if help_message:
+        print(f"  {color.red}╰> {help_message}{color.clear}")
 
 
 def main():
@@ -220,6 +253,10 @@ def main():
         show_stats = None
 
     if args.flag:
+        # Check if the flag is a valid flag
+        if not check_valid_argument("--flag", args.flag, list(flags)):
+            exit(1)
+
         # Draw the chosen flag and system information
         create_fetch(args.flag, show_stats, args.width)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -52,6 +52,9 @@ reset = "\033[0m\033[39m"
 # When printed, text will become bold
 bold = "\033[1m"
 
+# When printed, text will become red
+red = "\033[31m"
+
 
 def color256(col: int, bg_fg: str) -> str:
     # Alias to avoid manually typing out escape codes every time
@@ -146,6 +149,27 @@ def main():
     elif args.stats:
         # Collect chosen stats if they exist
         show_stats = args.stats.split(",")
+
+        # Remove empty string items and remove whitespaces
+        show_stats = [stat.strip() for stat in show_stats if stat.strip()]
+
+        # If the user has entered stats
+        if len(show_stats) > 0:
+            for stat in show_stats:
+                # If the stat isn't in stats, it isn't valid
+                if stat not in stats:
+                    # Tell the user the stat is invalid
+                    print(f"{bold}{red}Error: Invalid stat '{stat}' (does not exist){reset}")
+
+                    # Exit with an error code
+                    exit(1)
+
+        else:
+            # The user must have typed a comma without any stats
+            print(f"{bold}{red}Error: No stats given with '--stats'{reset}")
+
+            # Exit with an error code
+            exit(1)
 
     else:
         # Otherwise, use the default stats

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -39,11 +39,11 @@ flags = {
 
 # A dictionary of all the available stats
 stats = {
-    "os": distribution() or system() or 'N/A',
-    "arch": architecture() or 'N/A',
-    "pkgs": packages() or 'N/A',
-    "kernel": kernel() or system() or 'N/A',
-    "uptime": str(timedelta(seconds=clock_gettime(CLOCK_BOOTTIME))).split('.', 1)[0]
+    "os": lambda: distribution() or system() or 'N/A',
+    "arch": lambda: architecture() or 'N/A',
+    "pkgs": lambda: packages() or 'N/A',
+    "kernel": lambda: kernel() or system() or 'N/A',
+    "uptime": lambda: str(timedelta(seconds=clock_gettime(CLOCK_BOOTTIME))).split('.', 1)[0]
 }
 
 # When printed, reset will end the color of the row

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -4,7 +4,6 @@
 from argparse import ArgumentParser
 from datetime import timedelta
 from random import choice as random_choice
-from time import clock_gettime, CLOCK_BOOTTIME
 
 # Title - user@hostname
 from getpass import getuser
@@ -13,6 +12,7 @@ from socket import gethostname
 # System info modules
 from platform import platform as system
 from platform import release as kernel
+from time import clock_gettime, CLOCK_BOOTTIME
 from platform import machine as architecture
 from distro import name as distribution
 from modules.packages import get_num_packages as packages
@@ -34,7 +34,7 @@ flags = {
     "aromantic": [71, 149, 255, 249, 0],
     "agender": [0, 251, 255, 149, 255, 251, 0],
     "asexual": [0, 242, 255, 54],
-    "graysexual": [54, 242, 255, 242, 54],
+    "graysexual": [54, 242, 255, 242, 54]
 }
 
 # A dictionary of all the available stats
@@ -82,7 +82,7 @@ def generate_fetch(flag_name: str, show_stats=None, width=None):
         # Calculate the correct amount of spaces to keep the stat values in line with each other
         spaces = ((len(max(show_stats)) - len(stat)) + 1) * " "
 
-        # Generate a row
+        # Generate a row with color, stat name and its value
         row = f"{row_color}{stat}:{spaces}{reset}{value}"
 
         # Add the row to the data
@@ -119,7 +119,10 @@ def create_fetch(flag_name: str, show_stats=None, width=None):
     # Check if the flag exists in the dictionary of flags
     assert flag_name in flags.keys(), f"flag '{flag_name}' is not a valid flag"
 
+    # Generate a fetch with the given info
     flag, width, data = generate_fetch(flag_name, show_stats, width)
+
+    # Draw the fetch
     draw_fetch(flag, width, data)
 
 
@@ -127,7 +130,7 @@ def main():
     # Argument configuration - options
     parser = ArgumentParser()
     parser.add_argument("-l", "--list", help="lists all the flags and stats that can be displayed", action="store_true")
-    parser.add_argument("-a", "--all-stats", help="use all the available stats (overrides '--stats')", action="store_true")
+    parser.add_argument("-a", "--all-stats", help="use all available stats (overrides '--stats')", action="store_true")
     parser.add_argument("-f", "--flag", help="displays a flag of your choice")
     parser.add_argument("-r", "--random", help="randomly choose a flag from a comma-seperated list")
     parser.add_argument("-s", "--stats", help="choose the stats to appear from a comma-seperated list")

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -76,7 +76,7 @@ def generate_fetch(flag_name: str, show_stats=None, width=None):
 
     # Add the chosen stats to the list row_data
     for stat in show_stats:
-        value = stats[stat]
+        value = stats[stat]()
         row = f"{row_color}{stat}: {reset}{value}"
         data.append(row)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -49,6 +49,14 @@ stats = {
 
 
 def generate_fetch(flag_name: str, show_stats: list = None, width: int = None) -> (list, int, list):
+    """
+    Generates variables needed for a fetch
+    :param flag_name: The name of the flag to use
+    :param show_stats: Stats to show in the fetch
+    :param width: Custom width of the flag
+    :return: Generated flag data
+    """
+
     # Load the chosen flag from the dictionary of flags
     flag = flags[flag_name]
 
@@ -94,19 +102,33 @@ def generate_fetch(flag_name: str, show_stats: list = None, width: int = None) -
 
 
 def draw_fetch(flag: list, width: int, data: list) -> None:
+    """
+    Draws a fetch to the screen
+    :param flag: The flag as a list of colors
+    :param width: Width of the flag rows
+    :param data: System stats data
+    """
+
     # Print a blank line to separate the flag from the terminal prompt
     print()
 
     for index, row in enumerate(flag):
         # Print out each row of the fetch
-        print(f" {color.color256(row, 'bg')}{' ' * width}\033[49m{color.clear} "  # Flag line
-              f"{data[min(index, len(data) - 1)]}{color.clear}")  # Stats line
+        print(f" {color.color256(row, 'bg')}{' ' * width}\033[49m{color.clear} "  # Flag rows
+              f"{data[min(index, len(data) - 1)]}{color.clear}")  # Stats rows
 
     # Print a blank line again to separate the flag from the terminal prompt
     print()
 
 
 def create_fetch(flag_name: str, show_stats: list = None, width: int = None) -> None:
+    """
+    Creates a fetch, by generating and then drawing it
+    :param flag_name: The name of the flag to use
+    :param show_stats: Stats to show in the fetch
+    :param width: Custom width of the flag
+    """
+
     # Check if the flag exists in the dictionary of flags
     assert flag_name in flags.keys(), f"flag '{flag_name}' is not a valid flag"
 
@@ -118,6 +140,14 @@ def create_fetch(flag_name: str, show_stats: list = None, width: int = None) -> 
 
 
 def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list) -> bool:
+    """
+    Checks if arguments are valid
+    :param arg_flag: The argument flag e.g. --random, --stats etc.
+    :param arguments: A list of user inputted arguments
+    :param valid_arguments: The valid list of arguments to check against
+    :return: True if the arguments are valid, False if not
+    """
+
     # If there are any arguments remaining
     if len(arguments) > 0:
         for argument in arguments:
@@ -137,6 +167,14 @@ def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list)
 
 
 def parse_comma_arguments(arg_flag: str, comma_arguments: str, valid_arguments: list) -> list:
+    """
+    Parses comma seperated arguments and checks if they are valid
+    :param arg_flag: The argument flag e.g. --random, --stats etc.
+    :param comma_arguments: Raw string of user inputted arguments including commas
+    :param valid_arguments: The valid list of arguments to check against
+    :return: Parsed arguments if valid, exits the program if invalid
+    """
+
     # Separate arguments into a list
     arguments = comma_arguments.split(",")
 
@@ -153,9 +191,13 @@ def parse_comma_arguments(arg_flag: str, comma_arguments: str, valid_arguments: 
 
 
 def main():
+    """
+    Main function that evaluates command line arguments
+    """
+
     # Argument configuration - options
     parser = ArgumentParser()
-    parser.add_argument("-l", "--list", help="lists all the flags and stats that can be displayed", action="store_true")
+    parser.add_argument("-l", "--list", help="lists all flags and stats that can be displayed", action="store_true")
     parser.add_argument("-a", "--all-stats", help="use all available stats (overrides '--stats')", action="store_true")
     parser.add_argument("-f", "--flag", help="displays a flag of your choice")
     parser.add_argument("-r", "--random", help="randomly choose a flag from a comma-seperated list")

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -14,6 +14,8 @@ from platform import platform as system
 from platform import release as kernel
 from time import clock_gettime, CLOCK_BOOTTIME
 from platform import machine as architecture
+from typing import Tuple, List, Any
+
 from distro import name as distribution
 from modules.packages import get_num_packages as packages
 
@@ -61,7 +63,8 @@ def color256(col: int, bg_fg: str) -> str:
     return f"\033[{48 if bg_fg == 'bg' else 38};5;{col}m"
 
 
-def generate_fetch(flag_name: str, show_stats=None, width=None):
+def generate_fetch(flag_name: str, stat_choices: list = None, width: int = None) -> \
+        tuple[list[int | Any] | list[int] | Any, int | None, list[str]]:
     # Load the chosen flag from the dictionary of flags
     flag = flags[flag_name]
 
@@ -69,7 +72,7 @@ def generate_fetch(flag_name: str, show_stats=None, width=None):
     row_color = color256(flag[1] if flag[0] != flag[1] else flag[2], "fg")
 
     # Set default stats to show in the fetch
-    show_stats = show_stats or ["os", "pkgs", "kernel", "uptime"]
+    stat_choices = stat_choices or ["os", "pkgs", "kernel", "uptime"]
 
     # Initialise the fetch data (system info) to be displayed with the user@hostname
     data = [
@@ -78,12 +81,12 @@ def generate_fetch(flag_name: str, show_stats=None, width=None):
     ]
 
     # Add the chosen stats to the list row_data
-    for stat in show_stats:
+    for stat in stat_choices:
         # Calculate the value for the stat by running its function
         value = stats[stat]()
 
         # Calculate the correct amount of spaces to keep the stat values in line with each other
-        spaces = ((len(max(show_stats)) - len(stat)) + 1) * " "
+        spaces = ((len(max(stat_choices)) - len(stat)) + 1) * " "
 
         # Generate a row with color, stat name and its value
         row = f"{row_color}{stat}:{spaces}{reset}{value}"
@@ -118,12 +121,12 @@ def draw_fetch(flag: list, width: int, data: list):
     print()
 
 
-def create_fetch(flag_name: str, show_stats=None, width=None):
+def create_fetch(flag_name: str, stat_choices: list = None, width: int = None):
     # Check if the flag exists in the dictionary of flags
     assert flag_name in flags.keys(), f"flag '{flag_name}' is not a valid flag"
 
     # Generate a fetch with the given info
-    flag, width, data = generate_fetch(flag_name, show_stats, width)
+    flag, width, data = generate_fetch(flag_name, stat_choices, width)
 
     # Draw the fetch
     draw_fetch(flag, width, data)

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentParser
 from datetime import timedelta
 from random import choice as random_choice
+import color
 
 # Title - user@hostname
 from getpass import getuser
@@ -14,7 +15,6 @@ from platform import platform as system
 from platform import release as kernel
 from time import clock_gettime, CLOCK_BOOTTIME
 from platform import machine as architecture
-
 from distro import name as distribution
 from modules.packages import get_num_packages as packages
 
@@ -47,35 +47,21 @@ stats = {
     "uptime": lambda: str(timedelta(seconds=clock_gettime(CLOCK_BOOTTIME))).split('.', 1)[0]
 }
 
-# When printed, reset will end the color of the row
-reset = "\033[0m\033[39m"
-
-# When printed, text will become bold
-bold = "\033[1m"
-
-# When printed, text will become red
-red = "\033[31m"
-
-
-def color256(col: int, bg_fg: str) -> str:
-    # Alias to avoid manually typing out escape codes every time
-    return f"\033[{48 if bg_fg == 'bg' else 38};5;{col}m"
-
 
 def generate_fetch(flag_name: str, show_stats: list = None, width: int = None) -> (list, int, list):
     # Load the chosen flag from the dictionary of flags
     flag = flags[flag_name]
 
     # Make sure that the row color is different to the color of the hostname
-    row_color = color256(flag[1] if flag[0] != flag[1] else flag[2], "fg")
+    row_color = color.color256(flag[1] if flag[0] != flag[1] else flag[2], "fg")
 
     # Set default stats to show in the fetch
     show_stats = show_stats or ["os", "pkgs", "kernel", "uptime"]
 
     # Initialise the fetch data (system info) to be displayed with the user@hostname
     data = [
-        f"{color256(flag[0], 'fg') if flag[0] != 0 else color256(242, 'fg')}"
-        f"\033[1m{getuser()}@{gethostname()}{reset}",
+        f"{color.color256(flag[0], 'fg') if flag[0] != 0 else color.color256(242, 'fg')}"
+        f"\033[1m{getuser()}@{gethostname()}{color.clear}",
     ]
 
     # Add the chosen stats to the list row_data
@@ -87,7 +73,7 @@ def generate_fetch(flag_name: str, show_stats: list = None, width: int = None) -
         spaces = ((len(max(show_stats)) - len(stat)) + 1) * " "
 
         # Generate a row with color, stat name and its value
-        row = f"{row_color}{stat}:{spaces}{reset}{value}"
+        row = f"{row_color}{stat}:{spaces}{color.clear}{value}"
 
         # Add the row to the data
         data.append(row)
@@ -113,7 +99,8 @@ def draw_fetch(flag: list, width: int, data: list) -> None:
 
     for index, row in enumerate(flag):
         # Print out each row of the fetch
-        print(f" {color256(row, 'bg')}{' ' * width}\033[49m{reset} {data[min(index, len(data) - 1)]}{reset}")
+        print(f" {color.color256(row, 'bg')}{' ' * width}\033[49m{color.clear} "  # Flag line
+              f"{data[min(index, len(data) - 1)]}{color.clear}")  # Stats line
 
     # Print a blank line again to separate the flag from the terminal prompt
     print()
@@ -136,14 +123,14 @@ def check_valid_arguments(arg_flag: str, arguments: list, valid_arguments: list)
         for argument in arguments:
             # If the argument isn't in valid_arguments, it isn't valid
             if argument not in valid_arguments:
-                print(f"{bold}{red}Error: Invalid argument '{argument}' for '{arg_flag}'{reset}\n"
-                      f"  {red}╰> must be one of '{', '.join(valid_arguments)}'{reset}")
+                print(f"{color.bold}{color.red}Error: Invalid argument '{argument}' for '{arg_flag}'{color.clear}\n"
+                      f"  {color.red}╰> must be one of '{', '.join(valid_arguments)}'{color.clear}")
                 return False
 
     # Otherwise, the user must have typed comma(s) without any arguments
     else:
-        print(f"{bold}{red}Error: No arguments given for '{arg_flag}'{reset}\n"
-              f"  {red}╰> must be one of '{', '.join(valid_arguments)}'{reset}")
+        print(f"{color.bold}{color.red}Error: No arguments given for '{arg_flag}'{color.clear}\n"
+              f"  {color.red}╰> must be one of '{', '.join(valid_arguments)}'{color.clear}")
         return False
 
     return True
@@ -202,9 +189,9 @@ def main():
         create_fetch(random_choice(flag_choices), show_stats, args.width)
 
     elif args.list:
-        # List out all the available flags
-        print(f"{bold}Available flags:{reset}\n{', '.join(flags)}\n\n"
-              f"{bold}Available stats:{reset}\n{', '.join(stats)}")
+        # List out all the available flags and stats
+        print(f"{color.bold}Available flags:{color.clear}\n{', '.join(flags)}\n\n"
+              f"{color.bold}Available stats:{color.clear}\n{', '.join(stats)}")
 
     else:
         # By default, draw the classic flag

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -119,12 +119,17 @@ def main():
     parser.add_argument("-r", "--random", help="randomly choose a flag from a comma-seperated list")
     parser.add_argument("-s", "--stats", help="choose the stats to appear from a comma-seperated list")
     parser.add_argument("-w", "--width", help="choose a custom width for the flag", type=int)
+    parser.add_argument("-a", "--all-stats", help="use all the available stats (overrides '--stats')", action="store_true")
     parser.add_argument("-l", "--list", help="lists all the flags and stats that can be displayed", action="store_true")
 
     # Parse (collect) any arguments
     args = parser.parse_args()
 
-    if args.stats:
+    if args.all_stats:
+        # Add all the available stats to show_stats
+        show_stats = stats.keys()
+
+    elif args.stats:
         # Collect chosen stats if they exist
         show_stats = args.stats.split(",")
 

--- a/src/color.py
+++ b/src/color.py
@@ -1,0 +1,10 @@
+# ASCII colour codes for text
+clear = "\033[0m\033[39m"
+bold = "\033[1m"
+red = "\033[31m"
+
+
+def color256(col: int, bg_fg: str) -> str:
+    # Alias to avoid manually typing out escape codes every time for flags
+    return f"\033[{48 if bg_fg == 'bg' else 38};5;{col}m"
+

--- a/src/color.py
+++ b/src/color.py
@@ -1,4 +1,4 @@
-# ASCII colour codes for text
+# ASCII color codes for text
 clear = "\033[0m\033[39m"
 bold = "\033[1m"
 red = "\033[31m"

--- a/src/modules/packages.py
+++ b/src/modules/packages.py
@@ -24,6 +24,7 @@ def get_num_packages() -> (int, bool):
         try:
             # Get the length of the output of the command - the number of packages
             return len(check_output(command.split(" ")).decode("utf-8").split("\n")) - 1
+
         except FileNotFoundError:
             # If the command doesn't exist, skip it
             pass


### PR DESCRIPTION
This PR implements the ability to choose your own stats, with the `-s` or `--stats` flag.
For this to work, I've split the flag process up into two parts - actually calculating/creating it. It'll return some variables about the flag, then those can be used as parameters for drawing it.

I'll request @Minion3665 to look at this - especially suggesting variable names that are more suitable, as there's about 3 different stats at one time (not literally, but almost.)

**Todo:**
- [X] Add the ability to choose custom stats with an argument `--stats`
- [X] Show the available statistics with `--list`
- [x] Only import modules that are needed
- [x] Add an `all` stat - which just shows all the available stats, not the default ones
- [x] Add automatic spaces between the stat name and the value, as seen in the master branch

**Final checks:**
- [ ] Happy with variable names
- [ ] Happy with function names
- [ ] Happy with comments
- [ ] Happy with codestyle (pythonic)

⚠️ This is a draft, and should get merged once we're both happy - but for now there is definitely upcoming changes, as it's only an initial outline for the implementation.