### PR TITLE
remove apt in favour of neofetch's dpkg command

### DIFF
--- a/src/modules/packages.py
+++ b/src/modules/packages.py
@@ -4,8 +4,7 @@ commands = [
     "pacman -Qq --color never",  # Arch Linux
     "xbps-query -l",  # Void Linux
     "kiss l",  # KISS Linux
-    "apt list --installed",  # Debian, Ubuntu, Mint
-    "dpkg -l",  # Debian, Ubuntu, Mint
+    "dpkg-query -f '.\n' -W",  # Debian, Ubuntu, Mint
     "dnf list installed",  # Fedora
     "zypper search -i",  # openSUSE
     "rpm -qa",  # RHEL, Fedora Core, CentOS


### PR DESCRIPTION
`apt-get` does not have a "list" command like `apt` does, so I suggest using the `dpkg-query -f '.\n' -W` command used in neofetch. I've tested this against `apt list --installed` and turns out it's more accurate as the old command was adding an extra package by including a line which just said "Listing..."

This fixes #19.