### PR TITLE
Fixes for RHEL-based package commands

### DIFF
--- a/src/modules/packages.py
+++ b/src/modules/packages.py
@@ -2,14 +2,14 @@ from subprocess import check_output
 
 commands = [
     "pacman -Qq --color never",  # Arch Linux
-    "xbps-query -l",  # Void Linux
-    "kiss l",  # KISS Linux
     "dpkg-query -f '.\n' -W",  # Debian, Ubuntu, Mint
-    "dnf list installed",  # Fedora
-    "zypper search -i",  # openSUSE
+    "dnf list installed | tail -n +2",  # Fedora, RHEL
     "rpm -qa",  # RHEL, Fedora Core, CentOS
-    "yum list installed",  # RHEL, Fedora Core, CentOS
+    "yum list installed | tail -n +2",  # RHEL, Fedora Core, CentOS
+    "xbps-query -l",  # Void Linux
     "nix-store -qR /run/current-system/sw",  # NixOS
+    "zypper search -i",  # openSUSE
+    "kiss l",  # KISS Linux
     "equery list '*'",  # Gentoo
     "qlist -I",  # Gentoo
     "pkg info -a",  # BSDs

--- a/src/modules/packages.py
+++ b/src/modules/packages.py
@@ -7,7 +7,6 @@ commands = [
     "rpm -qa",  # RHEL, Fedora Core, CentOS
     "yum list installed | tail -n +2",  # RHEL, Fedora Core, CentOS
     "xbps-query -l",  # Void Linux
-    "nix-store -qR /run/current-system/sw",  # NixOS
     "zypper search -i",  # openSUSE
     "kiss l",  # KISS Linux
     "equery list '*'",  # Gentoo
@@ -15,6 +14,7 @@ commands = [
     "pkg info -a",  # BSDs
     "pkg_info",  # BSDs
     "apk info",  # Alpine
+    "nix-store -qR /run/current-system/sw",  # Nix
 ]
 
 


### PR DESCRIPTION
- Removes a line from `DNF` and `YUM` commands (to remove the title that's printed)
- `RPM` is only used if `DNF` and `YUM` are not available, as it includes gpg keys as packages so is less accurate
- Generally reorganises the commands so that more common distros are given priority