### PR TITLE
Add psutil to flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-kP4m7ZgFYj8fh7oW2L0uW0sJw/e0k1HY26HYJcvNEKM=",
-        "path": "/nix/store/ayvjhxw0zjwp5ipvwlhbhrwqqw553h2f-source",
-        "type": "path"
+        "lastModified": 1707877513,
+        "narHash": "sha256-sp0w2apswd3wv0sAEF7StOGHkns3XUQaO5erhWFZWXk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "89653a03e0915e4a872788d10680e7eec92f8600",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
@@ -14,11 +16,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1654245945,
-        "narHash": "sha256-PV6MZ+HuNnyLxQGa2rwt0BmCRkQS2xqhc+SeJLQM+WU=",
+        "lastModified": 1707877513,
+        "narHash": "sha256-sp0w2apswd3wv0sAEF7StOGHkns3XUQaO5erhWFZWXk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "442db9429b9fbdb6352cfb937afc8ecccfe2633f",
+        "rev": "89653a03e0915e4a872788d10680e7eec92f8600",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,12 @@
     in {
       pridefetch = pkgs-unstable.pridefetch.overrideAttrs (finalAttrs: previousAttrs: {
         src = builtins.path { path = ./.; name = "pridefetch"; };
+	buildInputs = [ 
+	  (pkgs-unstable.python3.withPackages (pythonPackages: with pythonPackages; [
+	    distro
+	    psutil
+	  ]))
+	];
       });
     });
 


### PR DESCRIPTION
Currently we're using the nixpkg for running pridefetch, but due to a version mismatch we are missing the psutil package. This results in errors when running pridefetch from this flake. Overriding the buildInputs is a temporary fix before we update this in nixpkgs.